### PR TITLE
make compatible with php 8.0

### DIFF
--- a/phing/tasks/GuzzleSubSplitTask.php
+++ b/phing/tasks/GuzzleSubSplitTask.php
@@ -337,6 +337,7 @@ class GuzzleSubSplitTask extends GitBaseTask
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         $result = curl_exec($ch);
         curl_close($ch);
+        unset($ch);
         $repos = json_decode($result, true);
         $existing_repos = array();
 
@@ -376,6 +377,7 @@ class GuzzleSubSplitTask extends GitBaseTask
                     $result = curl_exec($ch);
                     echo "Response code: ".curl_getinfo($ch, CURLINFO_HTTP_CODE)."\n";
                     curl_close($ch);
+                    unset($ch);
                 } else {
                     $this->log("Repo $reponame exists", 2);
                 }

--- a/src/Guzzle/Http/Curl/CurlHandle.php
+++ b/src/Guzzle/Http/Curl/CurlHandle.php
@@ -209,7 +209,7 @@ class CurlHandle
                 $args[] = $handle;
 
                 // PHP 5.5 pushed the handle onto the start of the args
-                if (is_resource($args[0])) {
+                if (false !== $args[0]) {
                     array_shift($args);
                 }
 
@@ -233,7 +233,7 @@ class CurlHandle
      */
     public function __construct($handle, $options)
     {
-        if (!is_resource($handle)) {
+        if (false === $handle) {
             throw new InvalidArgumentException('Invalid handle provided');
         }
         if (is_array($options)) {
@@ -259,8 +259,9 @@ class CurlHandle
      */
     public function close()
     {
-        if (is_resource($this->handle)) {
+        if (false !== $this->handle && null !== $this->handle) {
             curl_close($this->handle);
+            unset($this->handle);
         }
         $this->handle = null;
     }
@@ -272,7 +273,7 @@ class CurlHandle
      */
     public function isAvailable()
     {
-        return is_resource($this->handle);
+        return false !== $this->handle;
     }
 
     /**
@@ -322,7 +323,7 @@ class CurlHandle
      */
     public function getInfo($option = null)
     {
-        if (!is_resource($this->handle)) {
+        if (false === $this->handle) {
             return null;
         }
 

--- a/src/Guzzle/Http/Curl/CurlMulti.php
+++ b/src/Guzzle/Http/Curl/CurlMulti.php
@@ -58,7 +58,7 @@ class CurlMulti extends AbstractHasDispatcher implements CurlMultiInterface
 
     public function __destruct()
     {
-        if (is_resource($this->multiHandle)) {
+        if (false !== $this->multiHandle) {
             curl_multi_close($this->multiHandle);
         }
     }

--- a/src/Guzzle/Http/Message/Response.php
+++ b/src/Guzzle/Http/Message/Response.php
@@ -879,7 +879,7 @@ class Response extends AbstractMessage implements \Serializable
     {
         $errorMessage = null;
         $internalErrors = libxml_use_internal_errors(true);
-        $disableEntities = libxml_disable_entity_loader(true);
+        if (\PHP_VERSION_ID < 80000) $disableEntities = libxml_disable_entity_loader(true);
         libxml_clear_errors();
 
         try {
@@ -893,7 +893,7 @@ class Response extends AbstractMessage implements \Serializable
 
         libxml_clear_errors();
         libxml_use_internal_errors($internalErrors);
-        libxml_disable_entity_loader($disableEntities);
+        if (\PHP_VERSION_ID < 80000) libxml_disable_entity_loader($disableEntities);
 
         if ($errorMessage) {
             throw new RuntimeException('Unable to parse response body into XML: ' . $errorMessage);

--- a/tests/Guzzle/Tests/Http/Curl/CurlHandleTest.php
+++ b/tests/Guzzle/Tests/Http/Curl/CurlHandleTest.php
@@ -112,6 +112,7 @@ class CurlHandleTest extends \Guzzle\Tests\GuzzleTestCase
 
         // Mess it up by closing the handle
         curl_close($handle);
+        unset($handle);
         $this->assertFalse($h->isAvailable());
 
         // Mess it up by unsetting the handle
@@ -152,6 +153,7 @@ class CurlHandleTest extends \Guzzle\Tests\GuzzleTestCase
         $this->assertInternalType('array', $h->getInfo());
 
         curl_close($handle);
+        unset($handle);
         $this->assertEquals(null, $h->getInfo('url'));
     }
 

--- a/tests/Guzzle/Tests/Http/Curl/CurlMultiTest.php
+++ b/tests/Guzzle/Tests/Http/Curl/CurlMultiTest.php
@@ -46,7 +46,8 @@ class CurlMultiTest extends \Guzzle\Tests\GuzzleTestCase
     {
         $handle = $this->multi->getHandle();
         $this->multi->__destruct();
-        $this->assertFalse(is_resource($handle));
+        $is_resource = false !== $handle;
+        $this->assertFalse($is_resource);
     }
 
     public function testRequestsCanBeAddedAndCounted()


### PR DESCRIPTION
So the issues we are getting are caused by Curl being changed from a resource to an object as can be seen here:

https://php.watch/versions/8.0/resource-CurlHandle

Because they are no longer resources the is_resource() checks return false even though we do have a valid Curl object.

It's now recommended to check if the Curl handle is false.

Also now that they are no longer resources calling curl_close() is a no op on PHP 8 (but still works on previous versions) so now we also unset the Curl object to clean it up.

Finally libxml_disable_entity_loader() is deprecated on PHP 8 as the newer version of the XML library automatically handles this so a PHP less than 8 check has been added to these calls to prevent warnings this can be seen here:

https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation