### PR TITLE
Fixed PHP 8.1 deprecation warnings

### DIFF
--- a/src/Guzzle/Common/Collection.php
+++ b/src/Guzzle/Common/Collection.php
@@ -42,11 +42,13 @@ class Collection implements \ArrayAccess, \IteratorAggregate, \Countable, ToArra
         return new self($data);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->data);
@@ -291,21 +293,25 @@ class Collection implements \ArrayAccess, \IteratorAggregate, \Countable, ToArra
         return $collection;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->data[$offset]) ? $this->data[$offset] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->data[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);

--- a/src/Guzzle/Common/Collection.php
+++ b/src/Guzzle/Common/Collection.php
@@ -78,7 +78,7 @@ class Collection implements \ArrayAccess, \IteratorAggregate, \Countable, ToArra
      *
      * @return array Returns an array of all matching key value pairs
      */
-    public function getAll(array $keys = null)
+    public function getAll($keys = null)
     {
         return $keys ? array_intersect_key($this->data, array_flip($keys)) : $this->data;
     }

--- a/src/Guzzle/Common/Event.php
+++ b/src/Guzzle/Common/Event.php
@@ -20,26 +20,31 @@ class Event extends SymfonyEvent implements ToArrayInterface, \ArrayAccess, \Ite
         $this->context = $context;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->context);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->context[$offset]) ? $this->context[$offset] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->context[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->context[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->context[$offset]);

--- a/src/Guzzle/Common/Exception/ExceptionCollection.php
+++ b/src/Guzzle/Common/Exception/ExceptionCollection.php
@@ -60,6 +60,7 @@ class ExceptionCollection extends \Exception implements GuzzleException, \Iterat
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->exceptions);
@@ -70,6 +71,7 @@ class ExceptionCollection extends \Exception implements GuzzleException, \Iterat
      *
      * @return \ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->exceptions);

--- a/src/Guzzle/Common/Exception/ExceptionCollection.php
+++ b/src/Guzzle/Common/Exception/ExceptionCollection.php
@@ -13,7 +13,7 @@ class ExceptionCollection extends \Exception implements GuzzleException, \Iterat
     /** @var string Succinct exception message not including sub-exceptions */
     private $shortMessage;
 
-    public function __construct($message = '', $code = 0, \Exception $previous = null)
+    public function __construct($message = '', $code = 0, $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->shortMessage = $message;

--- a/src/Guzzle/Http/Client.php
+++ b/src/Guzzle/Http/Client.php
@@ -346,7 +346,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
      *
      * @return string
      */
-    protected function expandTemplate($template, array $variables = null)
+    protected function expandTemplate($template, $variables = null)
     {
         $expansionVars = $this->getConfig()->toArray();
         if ($variables) {

--- a/src/Guzzle/Http/Curl/CurlMulti.php
+++ b/src/Guzzle/Http/Curl/CurlMulti.php
@@ -118,6 +118,7 @@ class CurlMulti extends AbstractHasDispatcher implements CurlMultiInterface
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->requests);

--- a/src/Guzzle/Http/Curl/CurlMulti.php
+++ b/src/Guzzle/Http/Curl/CurlMulti.php
@@ -269,7 +269,7 @@ class CurlMulti extends AbstractHasDispatcher implements CurlMultiInterface
      * @param RequestInterface $request Request to remove
      * @param \Exception       $e       Exception encountered
      */
-    protected function removeErroredRequest(RequestInterface $request, \Exception $e = null)
+    protected function removeErroredRequest(RequestInterface $request, $e = null)
     {
         $this->exceptions[] = array('request' => $request, 'exception' => $e);
         $this->remove($request);

--- a/src/Guzzle/Http/Curl/CurlMultiProxy.php
+++ b/src/Guzzle/Http/Curl/CurlMultiProxy.php
@@ -105,6 +105,7 @@ class CurlMultiProxy extends AbstractHasDispatcher implements CurlMultiInterface
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->all());

--- a/src/Guzzle/Http/Message/Header.php
+++ b/src/Guzzle/Http/Message/Header.php
@@ -113,11 +113,13 @@ class Header implements HeaderInterface
         return $this->values;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->toArray());
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->toArray());

--- a/src/Guzzle/Http/Message/Header/HeaderCollection.php
+++ b/src/Guzzle/Http/Message/Header/HeaderCollection.php
@@ -64,16 +64,19 @@ class HeaderCollection implements \IteratorAggregate, \Countable, \ArrayAccess, 
         return $this->offsetGet($key);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->headers);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->headers[strtolower($offset)]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $l = strtolower($offset);
@@ -81,16 +84,19 @@ class HeaderCollection implements \IteratorAggregate, \Countable, \ArrayAccess, 
         return isset($this->headers[$l]) ? $this->headers[$l] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->add($value);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->headers[strtolower($offset)]);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->headers);

--- a/src/Guzzle/Http/Message/Response.php
+++ b/src/Guzzle/Http/Message/Response.php
@@ -160,7 +160,7 @@ class Response extends AbstractMessage implements \Serializable
         return $this->getMessage();
     }
 
-    public function serialize()
+    public function __serialize()
     {
         return json_encode(array(
             'status'  => $this->statusCode,
@@ -169,10 +169,20 @@ class Response extends AbstractMessage implements \Serializable
         ));
     }
 
-    public function unserialize($serialize)
+    public function __unserialize($serialize)
     {
         $data = json_decode($serialize, true);
         $this->__construct($data['status'], $data['headers'], $data['body']);
+    }
+
+    public function serialize()
+    {
+        return $this->__serialize();
+    }
+
+    public function unserialize($serialize)
+    {
+        $this->__unserialize($serialize);
     }
 
     /**

--- a/src/Guzzle/Http/QueryString.php
+++ b/src/Guzzle/Http/QueryString.php
@@ -157,7 +157,7 @@ class QueryString extends Collection
      * @return self
      * @see \Guzzle\Http\QueryString::aggregateUsingComma()
      */
-    public function setAggregator(QueryAggregatorInterface $aggregator = null)
+    public function setAggregator($aggregator = null)
     {
         // Use the default aggregator if none was set
         if (!$aggregator) {

--- a/src/Guzzle/Http/Url.php
+++ b/src/Guzzle/Http/Url.php
@@ -119,7 +119,7 @@ class Url
      * @param QueryString|array|string $query    Query string of the URL
      * @param string                   $fragment Fragment of the URL
      */
-    public function __construct($scheme, $host, $username = null, $password = null, $port = null, $path = null, QueryString $query = null, $fragment = null)
+    public function __construct($scheme, $host, $username = null, $password = null, $port = null, $path = null, $query = null, $fragment = null)
     {
         $this->scheme = $scheme;
         $this->host = $host;

--- a/src/Guzzle/Http/Url.php
+++ b/src/Guzzle/Http/Url.php
@@ -40,7 +40,7 @@ class Url
         $parts += $defaults;
 
         // Convert the query string into a QueryString object
-        if ($parts['query'] || 0 !== strlen($parts['query'])) {
+        if ($parts['query'] && 0 !== strlen($parts['query'])) {
             $parts['query'] = QueryString::fromString($parts['query']);
         }
 


### PR DESCRIPTION
Fixed PHP 8.1 deprecation warnings when using the Rackspace remote storage on the UpdraftPlus plugin.

The issues are caused by: 

1. PHP built-in class methods now have return types. Extending the built-in PHP class without a matching return type triggers the deprecation warnings. https://php.watch/versions/8.1/internal-method-return-types

   We need to add the `#[\ReturnTypeWillChange]` attribute to the class methods that are affected to avoid the deprecation messages but still have backward compatibility to PHP 5.

2. Implementing the `Serializable` interface without implementing `__serialize()` and `__unserialize()` methods is deprecated. https://php.watch/versions/8.1/serializable-deprecated

3. Passing `null` to the `strlen()` function is deprecated. https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation

